### PR TITLE
Fix ooyala player work properly in studio and display correctly in the LMS

### DIFF
--- a/ooyala_player/ooyala_player.py
+++ b/ooyala_player/ooyala_player.py
@@ -83,12 +83,12 @@ class OoyalaPlayerBlock(XBlock):
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/vendor/underscore.js'))
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/ooyala_player.js'))
 
-        transcript_js_url = textwrap.dedent('''
-                            //static.3playmedia.com/p/projects/{0}/files/{1}/embed.js?
-                            plugin=transcript&settings=width:640,height:240,skin:frost,
-                            can_collapse:true,collapse_onload:true,can_print:true,can_download:true,
-                            scan_view:true&player_type=ooyala&player_id={2}
-                            '''.format(self.transcript_project_id, self.transcript_file_id, self.player_id)
+        transcript_js_url = textwrap.dedent('''\
+        //static.3playmedia.com/p/projects/{0}/files/{1}/embed.js?
+        plugin=transcript&settings=width:640,height:240,skin:frost,
+        can_collapse:true,collapse_onload:true,can_print:true,can_download:true,
+        scan_view:true&player_type=ooyala&player_id={2}
+        '''.format(self.transcript_project_id, self.transcript_file_id, self.player_id)
                             )
 
         fragment.add_javascript_url(transcript_js_url)
@@ -107,7 +107,7 @@ class OoyalaPlayerBlock(XBlock):
         }))
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/ooyala_player_edit.js'))
 
-        fragment.initialize_js('OolayaPlayerEditBlock')
+        fragment.initialize_js('OoyalaPlayerEditBlock')
 
         return fragment
 
@@ -116,7 +116,8 @@ class OoyalaPlayerBlock(XBlock):
 
         self.display_name = submissions['display_name']
         self.content_id = submissions['content_id']
-        self.transcript_id = submissions['transcript_id']
+        self.transcript_file_id = submissions['transcript_file_id']
+        self.transcript_project_id = submissions['transcript_project_id']
 
         return {
             'result': 'success',

--- a/ooyala_player/templates/html/ooyala_player.html
+++ b/ooyala_player/templates/html/ooyala_player.html
@@ -1,7 +1,7 @@
 {% autoescape off %}
 <div class="ooyala-player-xblock-wrapper">
-    <div class="ooyala-player-container">
-        <div id='ooyalaplayer' class='ooyalaplayer' style='width:640px;height:360px' data-content-id='{{content_id}}' data-player-id='{{player_id}}' data-transcript-id='{{transcript_id}}'></div>
+    <div class="ooyala-player-container" style='width:640px;height:360px'>
+        <div id='ooyalaplayer' class='ooyalaplayer' data-content-id='{{content_id}}' data-player-id='{{player_id}}' data-transcript-id='{{transcript_id}}'></div>
         <div id="ooyala-overlay"></div>
     </div>
 


### PR DESCRIPTION
Studio changes: 
- Fix the transcript js url to be correct, it was containing invalid spaces in it, so the http request was failing.
- Fix the initialization method..... there was a typo in the name, so it wasn't called.
- Fix the studio edit attributes saving: there was typo in the key name, so it was crashing.

LMS Changes:

The video was badly displayed in the LMS (was overlaping with other elements), I simply fix the container size.
