### PR TITLE
Hide 'Scan view' mode

### DIFF
--- a/ooyala_player/public/css/transcript.css
+++ b/ooyala_player/public/css/transcript.css
@@ -121,5 +121,5 @@
 }
 
 .ooyala-player-xblock-wrapper .frost .scan-view {
-    display: none;
+    display: none !important;
 }


### PR DESCRIPTION
Avoid getting overridden by a DOM style attribute, set by the Ooyala JS.
