### PR TITLE
Reduced auto-scroll on transcript #MCKIN-1501

### DIFF
--- a/ooyala_player/ooyala_player.py
+++ b/ooyala_player/ooyala_player.py
@@ -193,7 +193,7 @@ class OoyalaPlayerBlock(XBlock):
             //static.3playmedia.com/p/projects/{0}/files/{1}/embed.js?
             plugin=transcript&settings=width:{2},height:340px,skin:frost,
             can_collapse:true,collapse_onload:true,can_print:true,can_download:true,
-            scan_view:true&player_type=ooyala&player_id={3}
+            scan_view:true,light_scroll:true&player_type=ooyala&player_id={3}
             '''.format(self.transcript_project_id, self.transcript_file_id, self.player_width, self.player_id))
 
             fragment.add_javascript_url(transcript_js_url)


### PR DESCRIPTION
Auto-scroll only when word gets toward the bottom of the visible transcript, as opposed to every line
