### PR TITLE
Enable query for transcript by video ID

### DIFF
--- a/ooyala_player/ooyala_player.py
+++ b/ooyala_player/ooyala_player.py
@@ -6,7 +6,7 @@
 import logging
 import textwrap
 import json
-from urllib2 import urlopen
+from urllib2 import urlopen, URLError
 
 from lxml import etree
 from StringIO import StringIO


### PR DESCRIPTION
New behavior for the xblock:

If transcript ID not defined, queries for the transcript using the Ooyala content ID.

Still needs to be implemented: 
- Display of transcript pulled via Ooyala content ID (template at `ooyala_player/templates/html/ooyala_player.html`relies purely on the transcript ID using `{% if transcript_file_id %}`) 
- Better error handling -- transcript should not display at all if there's an error (wrong API key, content not found, etc.) -- xblock should check for error and if transcript found, display the transcript to the user

Also: fixes a missing import for URLError.
