### PR TITLE
Solves a problem when performing fullscreen view in IE

### DIFF
--- a/ooyala_player/public/js/ooyala_player.js
+++ b/ooyala_player/public/js/ooyala_player.js
@@ -89,6 +89,11 @@ function OoyalaPlayerBlock(runtime, element) {
 
         });
 
+        // Set the z-index super-high in fullscreen mode, but not in normal mode; solves a problem in IE only
+        player.mb.subscribe(OO.EVENTS.FULLSCREEN_CHANGED, 'eventLogger', function(ev, payload) {
+            $('.ooyala-player-container', element).css('z-index', payload ? "999999" : "auto");
+        });
+
         function get_playback_rate() {
             if (is_html5_video) {
                 return video_node.playbackRate;


### PR DESCRIPTION
- doesn't actually go full screen, and higher z-indexed items do not get obscured. Set the z-index to be really high when in fullscreen, but it needs to be lower so that when scrolling higher indexed items still appear on top without being on top when in fullscreen.

@antoviaque - Any chance you can look at this? - or suggest a different solution; I have not found a CSS trick that works
