### PR TITLE
fullscreen-zindex: Revert to CSS-set z-index when exiting fullscreen

### DIFF
--- a/ooyala_player/public/js/ooyala_player.js
+++ b/ooyala_player/public/js/ooyala_player.js
@@ -91,7 +91,7 @@ function OoyalaPlayerBlock(runtime, element) {
 
         // Set the z-index super-high in fullscreen mode, but not in normal mode; solves a problem in IE only
         player.mb.subscribe(OO.EVENTS.FULLSCREEN_CHANGED, 'eventLogger', function(ev, payload) {
-            $('.ooyala-player-container', element).css('z-index', payload ? "999999" : "auto");
+            $('.ooyala-player-container', element).css('z-index', payload ? "999999" : "");
         });
 
         function get_playback_rate() {


### PR DESCRIPTION
Instead of setting the z-index to 'auto', remove the style added via the
.css() call to reuse the value set in the CSS stylesheets.

@Tivoli FYI
