### PR TITLE
variable-width: Only set fixed height by default

### DIFF
--- a/ooyala_player/ooyala_player.py
+++ b/ooyala_player/ooyala_player.py
@@ -86,18 +86,18 @@ class OoyalaPlayerBlock(XBlock):
         default=''
     )
 
-    player_width = String(
+    width = String(
         display_name="Player Width",
         help='The width of the player in pixels.',
         scope=Scope.content,
-        default="760px"
+        default="100%"
     )
 
-    player_height = String(
+    height = String(
         display_name="Player Height",
         help='The height of the player in pixels.',
         scope=Scope.content,
-        default="427px"
+        default="428px"
     )
 
     expiration_time = Integer(
@@ -235,8 +235,8 @@ class OoyalaPlayerBlock(XBlock):
             'player_token': self.player_token,
             'dom_id': dom_id,
             'overlay_fragments': overlay_fragments,
-            'player_width': self.player_width,
-            'player_height': self.player_height,
+            'width': self.width,
+            'height': self.height,
             'transcript_content': self.transcript,
             'transcript_error': self.transcript_error,
         }
@@ -335,8 +335,8 @@ class OoyalaPlayerBlock(XBlock):
             self.api_secret_key = submissions['api_secret_key']
             self.api_key_3play = submissions['api_key_3play']
             self.expiration_time = submissions['expiration_time']
-            self.player_width = submissions['player_width']
-            self.player_height = submissions['player_height']
+            self.width = submissions['width']
+            self.height = submissions['height']
 
         return response
 

--- a/ooyala_player/public/js/ooyala_player_edit.js
+++ b/ooyala_player/public/js/ooyala_player_edit.js
@@ -12,8 +12,8 @@ function OoyalaPlayerEditBlock(runtime, element) {
             'api_key': $('.edit-api-key', element).val(),
             'api_secret_key': $('.edit-api-secret-key', element).val(),
             'api_key_3play': $('.edit-api-key-3play', element).val(),
-            'player_width': $('.edit-player-width', element).val(),
-            'player_height': $('.edit-player-height', element).val(),
+            'width': $('.edit-width', element).val(),
+            'height': $('.edit-height', element).val(),
             'expiration_time': $('.edit-expiration-time', element).val(),
             'xml_config': xmlEditor.getValue()
         };

--- a/ooyala_player/templates/html/ooyala_player.html
+++ b/ooyala_player/templates/html/ooyala_player.html
@@ -1,6 +1,6 @@
 {% autoescape off %}
 <div class="ooyala-player-xblock-wrapper">
-    <div class="ooyala-player-container" style='width: {{player_width}}; height: {{player_height}};'>
+    <div class="ooyala-player-container" style='width: {{width}}; height: {{height}};'>
         <div id='{{dom_id}}' class='ooyalaplayer'
              data-content-id='{{content_id}}'
              data-dom-id='{{dom_id}}'

--- a/ooyala_player/templates/html/ooyala_player_edit.html
+++ b/ooyala_player/templates/html/ooyala_player_edit.html
@@ -66,15 +66,15 @@
       </li>
       <li class="field comp-setting-entry is-set">
           <div class="wrapper-comp-setting">
-            <label class="label setting-label" for="edit_player_width">Player Width</label>
-            <input class="input setting-input edit-player-width" id="edit_player_width" value="{{ self.player_width }}" type="text">
+            <label class="label setting-label" for="edit_width">Player Width</label>
+            <input class="input setting-input edit-width" id="edit_width" value="{{ self.width }}" type="text">
           </div>
           <span class="tip setting-help">Player width as a CSS length or percentage.</span>
       </li>
       <li class="field comp-setting-entry is-set">
           <div class="wrapper-comp-setting">
-            <label class="label setting-label" for="edit_player_height">Player Height</label>
-            <input class="input setting-input edit-player-height" id="edit_player_height" value="{{ self.player_height }}" type="text">
+            <label class="label setting-label" for="edit_height">Player Height</label>
+            <input class="input setting-input edit-height" id="edit_height" value="{{ self.height }}" type="text">
           </div>
           <span class="tip setting-help">Player height as a CSS length or percentage.</span>
       </li>

--- a/tests/test_ooyala_player.py
+++ b/tests/test_ooyala_player.py
@@ -70,8 +70,8 @@ def test_studio_submit_json_handler_valid_input():
         "api_secret_key": "exampleSecretKey",
         "api_key_3play": "example3playApiKey",
         "expiration_time": "exampleExpirationTime",
-        "player_width": "640px",
-        "player_height": "480px",
+        "width": "640px",
+        "height": "480px",
 
     }
     result = player.studio_submit(_MockRequest(request_data))
@@ -96,8 +96,8 @@ def test_studio_submit_json_handler_another_valid_input():
         "api_secret_key": "the_secret_key",
         "api_key_3play": "the_api_key_3play",
         "expiration_time": "10000",
-        "player_width": "320px",
-        "player_height": "280px",
+        "width": "320px",
+        "height": "280px",
 
     }
     result = player.studio_submit(_MockRequest(request_data))


### PR DESCRIPTION
Set player width to 100% by default, but player height to the default proportions for a 760px width. The player height doesn't automatically adjust to changing widths, and instead adds black lines to preserve the video proportions. With these defaults, we now allow for browser resizing, which can change the available width - the video will now reduce in size, and add black lines on top/bottom to compensate for the reduced width.

Also change variable names to video width/height to default values on existing courses.

@dragonfi @Tivoli Review/comments welcome
