### PR TITLE
Make Ooyala use the settings bucket to get its API key.

### DIFF
--- a/ooyala_player/ooyala_player.py
+++ b/ooyala_player/ooyala_player.py
@@ -315,10 +315,10 @@ class OoyalaPlayerBlock(OoyalaPlayerMixin, XBlock):
             return self.api_key_3play
 
         settings_service = self.runtime.service(self, 'settings')
-        try:
-            return settings_service.get('ENV_TOKENS')['XBLOCK_OOYALA_3PLAY_API']
-        except (AttributeError, KeyError):
-            return self.api_key_3play
+        if settings_service:
+            print settings_service.get_settings_bucket(self).get('3PLAY_API_KEY')
+            return settings_service.get_settings_bucket(self).get('3PLAY_API_KEY')
+        return None
 
     def local_resource_url(self, block, uri):
         # TODO move to xblock-utils


### PR DESCRIPTION
@bradenmacdonald @smarnach 

The settings service expects the API key to be available within lms.env.json in this format:

```
    "XBLOCK_SETTINGS": {
        "OoyalaPlayerBlock" : {
            "3PLAY_API_KEY": "fake_api_key"
        }
    },
```

Adding this to the top of your lms.env.json object should tell the Ooyala player your API key is "fake_api_key", which will be inert, of course, but you could use a print statement to verify it worked.