### PR TITLE
Fix for transcript print button not working in IE.

### DIFF
--- a/ooyala_player/public/js/ooyala_player.js
+++ b/ooyala_player/public/js/ooyala_player.js
@@ -159,6 +159,8 @@ function OoyalaPlayerBlock(runtime, element) {
         print_buttons.click(function () {
             w = window.open();
             w.document.write(content.html());
+            w.document.close();
+            w.focus();
             w.print();
             w.close();
         });


### PR DESCRIPTION
Fixes https://edx-wiki.atlassian.net/browse/MCKIN-3833

The trick is to close the popup's document before invoking the print() function:
http://stackoverflow.com/a/6040795/51397

Tested in IE 10 & 11, latest FF, Chrome, and Safari.