### PR TITLE
Changed default video for Ooyala player.

### DIFF
--- a/ooyala_player/ooyala_player.py
+++ b/ooyala_player/ooyala_player.py
@@ -226,7 +226,7 @@ class OoyalaPlayerBlock(OoyalaPlayerMixin, XBlock):
         display_name="Content Id",
         help="Identifier for the Content Id.",
         scope=Scope.content,
-        default='Q1eXg5NzpKqUUzBm5WTIb6bXuiWHrRMi'
+        default='RpOGxhMTE6p6DkTB8MBGtKN6v0_A_BdQ'
     )
 
     transcript_file_id = String(
@@ -415,7 +415,7 @@ class OoyalaPlayerLightChildBlock(OoyalaPlayerMixin, LightChild):
         display_name="Content Id",
         help="Identifier for the Content Id.",
         scope=LCScope.content,
-        default='Q1eXg5NzpKqUUzBm5WTIb6bXuiWHrRMi'
+        default='RpOGxhMTE6p6DkTB8MBGtKN6v0_A_BdQ'
     )
 
     transcript_file_id = LCString(

--- a/tests/test_ooyala_player.py
+++ b/tests/test_ooyala_player.py
@@ -29,6 +29,7 @@ def test_enabled_player_token_is_not_empty():
 class _MockRequest:
     def __init__(self, body):
         self.body = json.dumps(body)
+        self.method = "POST"
 
 
 class _NotEmpty:


### PR DESCRIPTION
Testing instructions: 

1. Add ``xblock-ooyala`` to your devstack 
2. Create a course, and add ``xblock-ooyala`` there, observe that default video is long and has bad audio. 
3. Checkout this branch. 
4. Add new ooyala player there, observe that you have a short video ending with: video upcoming. 