### PR TITLE
MCKIN-5257 Add data API to support native views and mobile downloads via Ooyala Mobile SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 xblock_image_explorer.egg-info
 *.pyc
+*.swp
 *~
-/.coverage
 /dist
 /xblock_ooyala_player.egg-info
 /node_modules
 .idea
+/var
+/.coverage
+/htmlcov

--- a/README.md
+++ b/README.md
@@ -122,23 +122,14 @@ Running tests
 1. In a virtualenv, run
 
 ```bash
-$ (cd ../xblock-sdk/; pip install -r requirements.txt)
-$ (cd ../xblock-ooyala/; pip install -r tests/requirements.txt)
+$ pip install -r tests/requirements.txt
+$ pushd $VIRTUAL_ENV/src/xblock-sdk/; make install; popd
 ```
 
-2. In the xblock-sdk repository, create the following configuration
-   file in `workbench/settings_ooyala.py`
-
-```python
-from settings import *
-
-INSTALLED_APPS += ('ooyala_player',)
-```
-
-3. To run the tests, from the xblock-ooyala repository root:
+2. To run the tests, from the xblock-ooyala repository root:
 
 ```bash
-$ DJANGO_SETTINGS_MODULE="workbench.settings_ooyala" nosetests --rednose --verbose --with-cover --cover-package=ooyala_player
+$ python run_tests.py --with-cover --cover-package=ooyala_player
 ```
 
 License

--- a/ooyala_player/tokens.py
+++ b/ooyala_player/tokens.py
@@ -11,7 +11,7 @@ def generate_player_token(partner_code, api_key, api_secret_key, video_code, exp
     expiry = _expiration_timestamp_from_delta(expiration_time)
     signature = _generate_signature(partner_code, api_key, api_secret_key, video_code, expiry)
 
-    return OOYALA_TOKEN_URL.format(partner_code, video_code, api_key, expiry, signature)
+    return OOYALA_TOKEN_URL.format(partner_code, video_code, api_key, expiry, signature), int(expiry)
 
 
 def _expiration_timestamp_from_delta(seconds):

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Run tests for the Ooyala PlayerXBlock
+
+This script is required to run our selenium tests inside the xblock-sdk workbench
+because the workbench SDK's settings file is not inside any python module.
+"""
+
+import os
+import sys
+import logging
+
+logging_level_overrides = {
+    'workbench.views': logging.ERROR,
+    'django.request': logging.ERROR,
+    'workbench.runtime': logging.ERROR,
+}
+
+if __name__ == "__main__":
+    # Use the workbench settings file:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "workbench.settings")
+    # Configure a range of ports in case the default port of 8081 is in use
+    os.environ.setdefault("DJANGO_LIVE_TEST_SERVER_ADDRESS", "localhost:8081-8099")
+
+    try:
+        os.mkdir('var')
+    except OSError:
+        # May already exist.
+        pass
+
+    from django.conf import settings
+    settings.INSTALLED_APPS += ("ooyala_player", )
+
+    for noisy_logger, log_level in logging_level_overrides.iteritems():
+        logging.getLogger(noisy_logger).setLevel(log_level)
+
+    from django.core.management import execute_from_command_line
+    args = sys.argv[1:]
+    paths = [arg for arg in args if arg[0] != '-']
+    if not paths:
+        paths = ["tests/"]
+    options = [arg for arg in args if arg not in paths]
+    execute_from_command_line([sys.argv[0], "test"] + paths + options)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,4 @@ coverage
 rednose
 
 -e .
+-e git://github.com/edx/xblock-sdk.git@v0.1.4#egg=xblock-sdk

--- a/tests/test_ooyala_player.py
+++ b/tests/test_ooyala_player.py
@@ -5,24 +5,28 @@ import json
 from xblock.field_data import DictFieldData
 
 from ooyala_player import OoyalaPlayerBlock
-import ooyala_player
+from xblock.runtime import DictKeyValueStore, KvsFieldData
+from xblock.test.tools import TestRuntime
+
+
+runtime = TestRuntime(field_data=KvsFieldData(DictKeyValueStore()))
 
 
 def test_player_token_is_disabled_by_default():
     field_data = DictFieldData({})
-    player = OoyalaPlayerBlock(None, field_data, None)
+    player = OoyalaPlayerBlock(runtime, field_data, None)
     assert_false(player.enable_player_token)
 
 
 def test_disabled_player_token_is_empty():
     field_data = DictFieldData({"enable_player_token": False})
-    player = OoyalaPlayerBlock(None, field_data, None)
+    player = OoyalaPlayerBlock(runtime, field_data, None)
     assert_equal(player.player_token, '')
 
 
 def test_enabled_player_token_is_not_empty():
     field_data = DictFieldData({"enable_player_token": True})
-    player = OoyalaPlayerBlock(None, field_data, None)
+    player = OoyalaPlayerBlock(runtime, field_data, None)
     assert_not_equal(player.player_token, '')
 
 
@@ -47,7 +51,7 @@ def _assert_studio_submit(result, expected):
 
 
 def test_studio_submit_json_handler_invalid_xml_config():
-    player = OoyalaPlayerBlock(None, None, None)
+    player = OoyalaPlayerBlock(runtime, None, None)
     request = _MockRequest({
         "xml_config": "this is clearly invalid xml"
     })
@@ -59,7 +63,7 @@ def test_studio_submit_json_handler_invalid_xml_config():
 
 
 def test_studio_submit_json_handler_valid_input():
-    player = OoyalaPlayerBlock(None, None, None)
+    player = OoyalaPlayerBlock(runtime, None, None)
     request_data = {
         "xml_config": "<tag>this is a valid xml</tag>",
         "display_name": "exampleDisplayName",
@@ -82,7 +86,7 @@ def test_studio_submit_json_handler_valid_input():
 
 
 def test_studio_submit_json_handler_another_valid_input():
-    player = OoyalaPlayerBlock(None, None, None)
+    player = OoyalaPlayerBlock(runtime, None, None)
     request_data = {
         "xml_config": (
             '<ooyala-player>'
@@ -120,7 +124,7 @@ class _MockOverlay:
 
 @mock.patch("ooyala_player.overlay.OoyalaOverlay", new=_MockOverlay)
 def test_parse_overlays():
-    player = OoyalaPlayerBlock(None, None, None)
+    player = OoyalaPlayerBlock(runtime, None, None)
     player.parent = "the_parent"
     player.content_id = "the_parent"
     player.xml_config = (

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -3,23 +3,17 @@ import mock
 import datetime
 
 from ooyala_player import tokens
+from .utils import MockNow
 
-# Mocks and helpers
-
-
-class _MockNow:
-    def __init__(self, mock_timestamp):
-        self._old_datetime = datetime.datetime
-        self.mock_timestamp = mock_timestamp
-
-    def now(self):
-        return self._old_datetime.fromtimestamp(self.mock_timestamp)
+# Helpers
 
 
 def _create_test_case(**kwargs):
+    expected_expiry = kwargs["expiration_time"] + datetime.datetime.mock_timestamp
+
     def expected_url():
         format_values = dict(kwargs)
-        format_values["expiration_time"] += datetime.datetime.mock_timestamp
+        format_values["expiration_time"] = expected_expiry
         expected_url = (
             'http://player.ooyala.com/sas/embed_token/{partner_code}/{video_code}?'
             'api_key={api_key}&'
@@ -32,14 +26,14 @@ def _create_test_case(**kwargs):
         params.pop("signature", None)
         return params
 
-    return expected_url(), input_params()
+    return expected_url(), input_params(), expected_expiry
 
 # Tests
 
 
-@mock.patch("datetime.datetime", new=_MockNow(10**10))
+@mock.patch("datetime.datetime", new=MockNow(10**10))
 def test_generate_player_token():
-    expected_url, input_params = _create_test_case(
+    expected_url, input_params, expected_expiry = _create_test_case(
         partner_code="field_partner_code",
         api_key="field_api_key",
         api_secret_key="field_api_secret_key",
@@ -48,13 +42,14 @@ def test_generate_player_token():
         signature="pThDB4rSxpQsDnVQuf7eO4grituDKp3z11uW5tiNFEg",
     )
 
-    result_url = tokens.generate_player_token(**input_params)
+    result_url, expiry = tokens.generate_player_token(**input_params)
     assert_equal(expected_url, result_url)
+    assert_equal(expected_expiry, expected_expiry)
 
 
-@mock.patch("datetime.datetime", new=_MockNow(10**10))
+@mock.patch("datetime.datetime", new=MockNow(10**10))
 def test_generate_player_token_with_other_parameters():
-    expected_url, input_params = _create_test_case(
+    expected_url, input_params, expected_expiry = _create_test_case(
         partner_code="examplePartnerCode1337",
         api_key="exampleApiKey1337",
         api_secret_key="exampleSecretKey1337",
@@ -63,13 +58,14 @@ def test_generate_player_token_with_other_parameters():
         signature="EOyl4QQ3OxDvPfRShHMb6oaK3Qp6c6g1Bbl%2BAsHmIWI"
     )
 
-    result_url = tokens.generate_player_token(**input_params)
+    result_url, expiry = tokens.generate_player_token(**input_params)
     assert_equal(expected_url, result_url)
+    assert_equal(expected_expiry, expiry)
 
 
-@mock.patch("datetime.datetime", new=_MockNow(11**10))
+@mock.patch("datetime.datetime", new=MockNow(11**10))
 def test_generate_player_token_at_another_time():
-    expected_url, input_params = _create_test_case(
+    expected_url, input_params, expected_expiry = _create_test_case(
         partner_code="examplePartnerCode1337",
         api_key="exampleApiKey1337",
         api_secret_key="exampleSecretKey1337",
@@ -78,8 +74,9 @@ def test_generate_player_token_at_another_time():
         signature="OBZGfULRcrq%2F1NPgNtjv%2FTMdE64l2k5wZe%2BrIDWiXKU"
     )
 
-    result_url = tokens.generate_player_token(**input_params)
+    result_url, expiry = tokens.generate_player_token(**input_params)
     assert_equal(expected_url, result_url)
+    assert_equal(expected_expiry, expiry)
 
 
 def test_generate_signature():
@@ -107,7 +104,7 @@ def _test_generate_signature(params, expected):
     assert_equal(result, expected)
 
 
-@mock.patch("datetime.datetime", new=_MockNow(0))
+@mock.patch("datetime.datetime", new=MockNow(0))
 def test_expiration_timestamp_from_delta():
     _expiration_timestamp_test(10000, 1000, "11000")
     _expiration_timestamp_test(12345000000, 98765, "12345098765")
@@ -119,4 +116,3 @@ def _expiration_timestamp_test(mock_now, delta, expected_string):
 
     result = tokens._expiration_timestamp_from_delta(delta)
     assert_equal(result, expected_string)
-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,31 @@
+# Test mocks and helpers
+import datetime
+from xblock.runtime import DictKeyValueStore, KvsFieldData
+from xblock.test.tools import TestRuntime
+
+
+class MockNow(object):
+    """
+    Provides a mock timestamp and now() method.
+
+    Usage:
+        @mock.patch("datetime.datetime", new=MockNow(10**10))
+        def test_something():
+            ...
+
+    """
+    def __init__(self, mock_timestamp):
+        self._old_datetime = datetime.datetime
+        self.mock_timestamp = mock_timestamp
+
+    def now(self):
+        return self._old_datetime.fromtimestamp(self.mock_timestamp)
+
+
+class MockRuntime(TestRuntime):
+    """
+    Provides a mock XBlock runtime object.
+    """
+    def __init__(self, **kwargs):
+        field_data = kwargs.get('field_data', KvsFieldData(DictKeyValueStore()))
+        super(MockRuntime, self).__init__(field_data=field_data)


### PR DESCRIPTION
Adds the `student_view_data` method, which returns the data necessary for streaming videos via the Ooyala Mobile SDK.

The `student_view_data` method also returns the `player_token` URL and `player_token_expires` timestamp. These values are not required for streaming playback from the Mobile SDK, but will be useful when the apps are updated to support video downloading (e.g [DownloadToOwnSampleApp](https://github.com/ooyala/ios-sample-apps/blob/2c7ce0584a7a88b34c08edc78daad29f070e7cec/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Utils/BasicEmbedTokenGenerator.m)).

**JIRA tickets**: MCKIN-5257

**Partner information**: 3rd party-hosted open edX instance

**Testing instructions**:

1. Install this branch in your devstack:
    ```bash
    sudo su edxapp
    cd /edx/src/xblock-ooyala
    pip install -e .
    ```
1. Use `NO_PREREQ_INSTALL=1 paver run_all_servers --settings=devstack` to run both LMS and Studio in the same session.  The `run_all_servers` command is required to allow the LMS's Course Blocks API so that the cache can be cleared when Studio publishes a course.
1. In Studio, create a course .
1. Add `"ooyala-player"` to the advanced modules list
1. Add an Ooyala Player component to your course and configure it using your video Content ID, e.g.
    * Content ID: `5sMHA1YzE6KHI-dFSKgDz-pcMOx37_f9`
1. Verify that the video plays as expected.
1. Publish the unit.
1. Visit the [Course Blocks API](http://edx.readthedocs.io/projects/edx-platform-api/en/latest/courses/blocks.html#query-parameters) endpoint for your course, with the following parameters, e.g.,
    ```
    http://localhost:8000/api/courses/v1/blocks/?course_id=OpenCraft%2Fooyala%2F2017_1&all_blocks=true&depth=all&student_view_data=ooyala-player
    ```
    *Note:* If your LMS user doesn't have staff privileges, use `username=<lms_username>` instead of `all_blocks=true`.
    The output should show `student_view_data` for your `ooyala-player` block, e.g.
    ```js
    "i4x://OpenCraft/ooyala/ooyala-player/a16265917f5149daaa13c03c6fd8297d": {
            "type": "ooyala-player",
            ...
            "student_view_data": {
                "content_id": "5sMHA1YzE6KHI-dFSKgDz-pcMOx37_f9",
                "player_token_expires": null,
                "player_token": "",
                "partner_code": ""
            },
        },
    ```
1. Edit your Ooyala Player component to add your Partner Code, API Key and Secret.
   You will need an Ooyala Backlot account to perform this step.
    * Enable Player Token: True
    * Partner Code: See [docs](http://help.ooyala.com/video-platform/concepts/api_keys.html) for how to extract the pcode from your API key.
    * API Key: your API key
    * API Secret: your API secret
1. Publish the unit.
1. Refresh the Course Blocks API from step 8, and note the additional response data, e.g.,
    ```js
    "i4x://OpenCraft/ooyala/ooyala-player/a16265917f5149daaa13c03c6fd8297d": {
            "type": "ooyala-player",
            ...
            "student_view_data": {
                "content_id": "5sMHA1YzE6KHI-dFSKgDz-pcMOx37_f9",
                "player_token_expires": 1501812713,
                "player_token": "http://player.ooyala.com/sas/embed_token/53YWsyOszKOsfS1...",
                "partner_code": "53YWsyOszKOsfS1IvcQoKn8YhWYk"
            },
        },
    ```

To verify that this data API is sufficient for streaming videos from the Ooyala Mobile SDK, follow the Getting Started instructions on either the Ooyala [ios-sample-apps](https://github.com/ooyala/ios-sample-apps) or [android-sample-apps](https://github.com/ooyala/android-sample-apps) repos.

*Tip* I used `--depth 1` when cloning the sample app repos, because they're pretty large.

Both the iOS and Android sample repos contain a `BasicPlaybackSampleApp`, which displays a hardcoded list of videos.  The basic procedure verification procedure is:

1. Add an entry to that list using the `student_view_data` values.  Note that:
    * `embedCode` corresponds to `content_id`
    * `pcode` corresponds to `partner_code`
    * `domain` is where your XBlock runs from, e.g. `http://localhost:8000`
    * `player_token` is not required for video streaming, but will be used for video download.
1. Run the app.
1. Verify that your new video plays in the app as expected.
1. To verify that domain restrictions apply for video playback in the app, you'll need to use a video whose settings you can modify.
    * Login to the [Ooyala Backlot](https://backlot.ooyala.com/backlot/web#publish_tab).
    * Under Publish > Syndication Controls, tick the "Domain Controls" checkbox.
    * Add your devstack domain under the "Users cannot embed content" list of domains.
      Note that if you used "http://example.com:8001" in the video entry you added to the app, then you can block access from the app by using any of these variations: `http://example.com`, `http://example.com:8001`, `https://example.com`, `https://example.com:8000`
1. Try to watch your video again -- it should fail to play.


*iOS SDK*

Add a new [`PlayerSelectionOption`](https://github.com/ooyala/ios-sample-apps/blob/b8b9bba6bc86f4fd895efb2305d3b3a18378e056/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Utils/PlayerSelectionOption.m#L14) to [BasicPlaybackListViewController.m](https://github.com/ooyala/ios-sample-apps/blob/b8b9bba6bc86f4fd895efb2305d3b3a18378e056/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Lists/BasicPlaybackListViewController.m#L31-L35), e.g.,
```objectivec
    - (void)addAllBasicPlayerSelectionOptions {
      [self insertNewObject: [[PlayerSelectionOption alloc] initWithTitle:@"Kwatile"
                                                                embedCode:@"5sMHA1YzE6KHI-dFSKgDz-pcMOx37_f9"
                                                                    pcode:@"53YWsyOszKOsfS1IvcQoKn8YhWYk"
                                                                   domain:@"http://localhost:8001"
                                                           viewController: [BasicSimplePlayerViewController class]]];
    ...
```

*Android SDK*

Add a new add a new [`PlayerSelectionOption`](https://github.com/ooyala/android-sample-apps/blob/640e5e400eb6af519c95b38cb544d9d1de5ed416/BasicPlaybackSampleApp/app/src/main/java/com/ooyala/sample/utils/PlayerSelectionOption.java#L9) to  [BasicPlaybackListActivity.java](https://github.com/ooyala/android-sample-apps/blob/stable/BasicPlaybackSampleApp/app/src/main/java/com/ooyala/sample/lists/BasicPlaybackListActivity.java#L37), e.g.,
```java
  @Override
  public void onCreate(Bundle savedInstanceState) {
    super.onCreate(savedInstanceState);
    setTitle(getName());

    selectionMap = new LinkedHashMap<String, PlayerSelectionOption>();
    //Populate the embed map
    selectionMap.put( "Kwatile", new PlayerSelectionOption("5sMHA1YzE6KHI-dFSKgDz-pcMOx37_f9", "53YWsyOszKOsfS1IvcQoKn8YhWYk", "http://localhost:8001", BasicPlaybackVideoPlayerActivity.class) );
    ...
```

**Author Notes & Concerns**

Since rebasing on `player_v4_with_translations`, the unit tests are failing for two tests unrelated to this change. CC @naeem91 
```
======================================================================
ERROR: tests.test_ooyala_player.test_studio_submit_json_handler_valid_input
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/edx/src/venvs/xblock-ooyala/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/edx/src/xblock-ooyala/tests/test_ooyala_player.py", line 127, in test_studio_submit_json_handler_valid_input
    result = player.studio_submit(_MockRequest(request_data))
  File "/edx/src/venvs/xblock-ooyala/local/lib/python2.7/site-packages/xblock/mixins.py", line 68, in wrapper
    response = func(self, request_json, suffix)
  File "/edx/src/xblock-ooyala/ooyala_player/ooyala_player.py", line 439, in studio_submit
    self.disable_cc_and_translations = submissions['cc_disable']
KeyError: 'cc_disable'

======================================================================
ERROR: tests.test_ooyala_player.test_studio_submit_json_handler_another_valid_input
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/edx/src/venvs/xblock-ooyala/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/edx/src/xblock-ooyala/tests/test_ooyala_player.py", line 153, in test_studio_submit_json_handler_another_valid_input
    result = player.studio_submit(_MockRequest(request_data))
  File "/edx/src/venvs/xblock-ooyala/local/lib/python2.7/site-packages/xblock/mixins.py", line 68, in wrapper
    response = func(self, request_json, suffix)
  File "/edx/src/xblock-ooyala/ooyala_player/ooyala_player.py", line 439, in studio_submit
    self.disable_cc_and_translations = submissions['cc_disable']
KeyError: 'cc_disable'
```

**Reviewers**
- [ ] @haikuginger 
- [ ] edX reviewer[s] TBD