### PR TITLE
System wide settings for ooyala partner code

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+Django>=1.8, <1.9
 mock
 nose
 coverage


### PR DESCRIPTION
Add default properties for `enable_player_token`, `partner_code`, `api_key`, and `api_secret_key`, much like is currently done for the [3Play API key](https://github.com/edx-solutions/xblock-ooyala/blob/7889c12/ooyala_player/ooyala_player.py#L361-L369).

**JIRA tickets**: [OC-3020](https://tasks.opencraft.com/browse/OC-3020) [MCKIN-5675](https://edx-wiki.atlassian.net/browse/MCKIN-5675)

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:

1. Specify Ooyala XBlock settings in your devstack that correspond to one of the above settings that you'd like to test
* Without specifying a value on the course XBlock instance, access one of the new default properties somehow. It should return the default value you've assigned in your project settings.
* Set an instance value, and see that the method / property now returns this value rather than the default
* Run the unit test

**Author notes and concerns**:
This feels a bit clunky – is having a method / property per default field the right way to go? 

**Reviewers**
- [x] @mtyaka 
