### PR TITLE
[MCKIN-5840] Error using some APIs due to xblock-ooyala.

### DIFF
--- a/ooyala_player/tokens.py
+++ b/ooyala_player/tokens.py
@@ -23,8 +23,8 @@ def _generate_signature(partner_code, api_key, api_secret_key, video_code, expir
     slug = "/sas/embed_token/"
 
     # Request string with parameters
-    request_path = slug + partner_code + "/" + video_code
-    request_string = api_secret_key + http_method + request_path + api_key + expiry
+    request_path = slug + str(partner_code) + "/" + str(video_code)
+    request_string = str(api_secret_key) + http_method + request_path + str(api_key) + str(expiry)
 
     # Generate a SHA-256 digest in base64 for request string
     m = hashlib.sha256()


### PR DESCRIPTION
We're making the assumption that all the params passed into `_generate_signature` are strings, and try to concatenate them. This fails when one of those params come in as a non-string value. So we force them into strings for token generation.

**Merge deadline**: ASAP

**Testing instructions**:

1. Configure an invalid Ooyala API key.
1. Ensure that we do not get the same error at this point.

**Reviewers**
- [ ] @bradenmacdonald 