### PR TITLE
MCKIN-6161: Allows Ooyala child blocks to be embedded in Adventure XBlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,10 @@ Running tests
 1. In a virtualenv, run
 
 ```bash
+$ pip install -r requirements.txt
 $ pip install -r tests/requirements.txt
 $ pushd $VIRTUAL_ENV/src/xblock-sdk/; make install; popd
+$ pushd $VIRTUAL_ENV/src/xblock-mentoring/; pip install -r requirements.txt; popd
 ```
 
 2. To run the tests, from the xblock-ooyala repository root:

--- a/ooyala_player/ooyala_player.py
+++ b/ooyala_player/ooyala_player.py
@@ -69,7 +69,7 @@ class OoyalaPlayerMixin(object):
         if available_attr:
             return available_attr
 
-        if getattr(self.runtime, 'service'):
+        if getattr(self.runtime, 'service') and hasattr(self, 'service_declaration'):
             settings_service = self.runtime.service(self, 'settings')
             if settings_service:
                 setting_name = self.DEFAULT_ATTRIBUTE_SETTINGS[attribute_name]

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ BLOCKS_CHILDREN = [
 
 setup(
     name='xblock-ooyala-player',
-    version='2.0.11',
+    version='2.0.12',
     description='XBlock - Ooyala Video Player',
     packages=['ooyala_player'],
     install_requires=[


### PR DESCRIPTION
Ensures that both `settings` and `settings_declaration` are available before requesting information from the settings service.  Also adds tests for OoyalaLightChildBlock to verify fix.

**JIRA tickets**: Fixes MCKIN-616, OC-3212

**Testing instructions**:

To verify issue, follow these steps with and [xblock-adventure@ 7bdeb62](https://github.com/edx-solutions/edx-platform/blob/master/requirements/edx/custom.txt#L10) installed:
1. Import the attached course in Studio: [MCKIN-6161.tar.gz](https://github.com/edx-solutions/xblock-ooyala/files/1406214/MCKIN-6161.tar.gz)
1. Navigate to the Course Outline > Section > Subsection > Unit.
1. When [xblock-ooyala@v2.0.11](https://github.com/edx-solutions/edx-platform/blob/master/requirements/edx/custom.txt#L8) is installed, Studio displays an error, and the logs report, `AttributeError: 'OoyalaPlayerLightChildBlock' object has no attribute 'service_declaration'`
1. When this branch is installed, Studio shows the text `Ooyala-player child will be displayed in the LMS.`

See the updated [README.md#running-tests](https://github.com/open-craft/xblock-ooyala/blob/jill/MCKIN-6161/README.md#running-tests) for instructions to run automated tests.

**Reviewers**
- [x] @mtyaka 