### PR TITLE
MCKIN-8967 Imported transcripts not loading

### DIFF
--- a/ooyala_player/ooyala_player.py
+++ b/ooyala_player/ooyala_player.py
@@ -449,12 +449,14 @@ class OoyalaPlayerBlock(OoyalaPlayerMixin, XBlock):
         Store user's cc language selection
         """
         threeplay_id = data.get('threeplay_id')
+        transcript_id = data.get('transcript_id')
         content = ''
 
         if threeplay_id:
             content = Transcript.get_transcript_by_threeplay_id(
                 api_key=self.get_attribute_or_default('api_key_3play'),
-                threeplay_id=threeplay_id
+                threeplay_id=threeplay_id,
+                transcript_id=transcript_id,
             )
 
         return {'content': content}

--- a/ooyala_player/public/js/ooyala_player.js
+++ b/ooyala_player/public/js/ooyala_player.js
@@ -286,11 +286,12 @@ function OoyalaPlayerBlock(runtime, element) {
                 if(langElement.hasClass('imported-transcript')){
                     // need to load transcript ourselves
                     var threeplayId = langElement.data('3play-id');
+                    var trascriptId = langElement.data('transcript-id');
                     var transcriptUrl = runtime.handlerUrl(element, 'load_transcript');
 
                     $.ajax({
                         type: "POST",
-                        data: JSON.stringify({'threeplay_id': threeplayId}),
+                        data: JSON.stringify({'threeplay_id': threeplayId, 'transcript_id': trascriptId}),
                         url: transcriptUrl,
                         context: this,
                         success: function (data) {

--- a/ooyala_player/templates/html/ooyala_transcript.html
+++ b/ooyala_player/templates/html/ooyala_transcript.html
@@ -17,7 +17,7 @@
                     <li data-lang-name="{{link.language}}" data-lang-code="{{link.lang_code}}" data-lang-dir="{{link.dir}}" class="transcript-track p3sdk-interactive-transcript-track {% if link.selected %}selected{% endif %}" remote-src="{{link.url}}">{{link.localized_name}}</li>
                 {% endfor %}
                 {% for link in self.imported_translations %}
-                    <li data-3play-id="{{link.threeplay_id}}" data-lang-name="{{link.language}}" data-lang-code="{{link.lang_code}}" data-lang-dir="{{link.dir}}" class="transcript-track imported-transcript {% if link.selected %}selected{% endif %}">{{link.localized_name}}</li>
+                    <li data-3play-id="{{link.threeplay_id}}" data-transcript-id="{{link.transcript_id}}" data-lang-name="{{link.language}}" data-lang-code="{{link.lang_code}}" data-lang-dir="{{link.dir}}" class="transcript-track imported-transcript {% if link.selected %}selected{% endif %}">{{link.localized_name}}</li>
                 {% endfor %}
                 </ul>
                 <ul>

--- a/ooyala_player/transcript.py
+++ b/ooyala_player/transcript.py
@@ -161,6 +161,7 @@ class Transcript(object):
                         if language and lang_code and threeplay_id:
                             self.imported_translations.append({
                                 'threeplay_id': threeplay_id,
+                                'transcript_id': self.transcript_id,
                                 'language': language,
                                 'lang_code': lang_code,
                                 'selected': True if selected_lang in [language, lang_code] else False,
@@ -169,10 +170,11 @@ class Transcript(object):
                             })
 
     @staticmethod
-    def get_transcript_by_threeplay_id(api_key, threeplay_id):
+    def get_transcript_by_threeplay_id(api_key, transcript_id, threeplay_id):
         transcript_content = ''
-        api_endpoint = "http://api.3playmedia.com/files/1340681/transcript.html?apikey={api_key}" \
-                       "&threeplay_transcript_id={threeplay_id}".format(api_key=api_key, threeplay_id=threeplay_id)
+        api_endpoint = "http://api.3playmedia.com/files/{file_id}/transcript.html?apikey={api_key}" \
+                       "&threeplay_transcript_id={threeplay_id}"\
+            .format(file_id=transcript_id, api_key=api_key, threeplay_id=threeplay_id)
 
         try:
             response = urlopen(api_endpoint)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ BLOCKS_CHILDREN = [
 
 setup(
     name='xblock-ooyala-player',
-    version='2.0.18',
+    version='2.0.19',
     description='XBlock - Ooyala Video Player',
     packages=['ooyala_player'],
     install_requires=[


### PR DESCRIPTION
Issue:
Self imported transcripts are not loading. 

Testing instructions:
1. Use master branch of Ooyala Xblock
2. Add a new Ooyala xblock component in a lesson
3. Use content id: **FobTE2ZzE6eaRs0JVDLhgBZuKjlnLu8u** (do it on an environment where 3play api key is set)
4. See the transcripts section below videos. Click on espanol and observe following error:
<img width="886" alt="screen shot 2018-12-01 at 1 57 17 pm" src="https://user-images.githubusercontent.com/6681794/49326241-207d6b00-f571-11e8-9cd1-372564f21e0b.png">

5. Use this PR branch `import-transcript-fix` and repeat the above steps. Transcript should now load fine.
<img width="937" alt="screen shot 2018-12-01 at 2 00 35 pm" src="https://user-images.githubusercontent.com/6681794/49326256-80741180-f571-11e8-8fda-eeedb523d30c.png">
