### PR TITLE
[MCKIN-10391] Fix issue with completion reporting on latest solutions code

### DIFF
--- a/ooyala_player/ooyala_player.py
+++ b/ooyala_player/ooyala_player.py
@@ -212,7 +212,7 @@ class OoyalaPlayerMixin(I18NService):
             # In certain cases we want to know when a student has visited a video player
             # as an indication that they are progressing through a course
             # Progress *does not* mean progress over viewing a video (i.e. elapsed time)
-            self.runtime.publish(self, 'progress', {})
+            self.runtime.publish(self, 'completion', {"completion": 1.0})
 
         return fragment
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ BLOCKS_CHILDREN = [
 
 setup(
     name='xblock-ooyala-player',
-    version='2.0.22',
+    version='2.0.23',
     description='XBlock - Ooyala Video Player',
     packages=['ooyala_player'],
     install_requires=[


### PR DESCRIPTION
The OOyala xblock has custom completion but was publishing a progress event instead of a completion event, which is no longer supported.

This PR updates the block to use the new completion API instead.


**Testing instructions:**
1. Set up a course with a OOyala xblock.
2. Visit an ooyala block page. 
3. It will not be marked as complete immediately on vew. 
4. Install the block from this PR.  
5. Visist an ooyala block page. 
6. It should be marked complete immideately (without a 5-second delay). 