### PR TITLE
MCKIN-19583 - CC and transcript match logic

### DIFF
--- a/ooyala_player/public/js/brightcove_player.js
+++ b/ooyala_player/public/js/brightcove_player.js
@@ -226,6 +226,22 @@ function BrightcovePlayerXblock(runtime, element) {
                 currentSelected.trigger('click');
             }else{
                 var transcripts = $('.transcript-track', element);
+
+                // give a try to 2 letter scheme
+                var userLang = this.transcriptLang.substr(0, 2);
+                transcripts.each(function(){
+                   var transcriptLang = $(this).data('lang-code').substr(0, 2);
+                   if(transcriptLang == userLang){
+                     currentSelected = $(this);
+                   }
+                });
+
+                if(currentSelected.length){
+                  currentSelected.trigger('click');
+                  return;
+                }
+
+                // select first language
                 if(transcripts.length) {
                     currentSelected = $(transcripts[0]);
                     currentSelected.trigger('click');

--- a/ooyala_player/public/js/brightcove_player.js
+++ b/ooyala_player/public/js/brightcove_player.js
@@ -75,10 +75,21 @@ function BrightcovePlayerXblock(runtime, element) {
                     });
                 }
 
-                if (this.transcriptLang != this.ccLang){
+                if (!this.ccAndTranscriptMatch()){
                     var langElement = $('.transcript-track', element).filter(
                         '[data-lang-code=' + this.ccLang + '], [data-lang-name=' + this.ccLang + ']'
                     );
+
+                    if(langElement.length == 0){
+                      // try a 2 letter scheme for match
+                      var ccLang = this.ccLang.substr(0, 2);
+                      $('.transcript-track', element).each(function(){
+                         var transcriptLang = $(this).data('lang-code').substr(0,2);
+                         if(transcriptLang == ccLang){
+                           langElement = $(this);
+                         }
+                      });
+                    }
 
                     langElement.trigger('click');
                 }
@@ -142,7 +153,7 @@ function BrightcovePlayerXblock(runtime, element) {
                 }
             },
             transcriptChanged: function(){
-                if(this.ccLang == this.transcriptLang || this.data.ccLang == 'off')
+                if(this.ccAndTranscriptMatch() || this.data.ccLang == 'off')
                     return;
 
                 // change CC accordingly
@@ -162,10 +173,26 @@ function BrightcovePlayerXblock(runtime, element) {
                     }
                 }
 
-                // if user selected cc dosn't exist, select the first available
+                // if user selected cc doesn't exist, try using 2 letter codes
+                // ignoring dialetcs
                 if(trackFound === false){
+                    var transcriptLang = this.transcriptLang.substr(0, 2);
                     for (var i = 0; i < (tracks.length); i++) {
                         var trackLang = tracks[i].language.substr(0, 2);
+                        if (trackLang === transcriptLang) {
+                            tracks[i].mode = "showing";
+                            this.ccLang = this.transcriptLang;
+                            trackFound = true;
+                        }else {
+                            tracks[i].mode = "disabled";
+                        }
+                    }
+                }
+
+                // if user selected cc doesn't exist, select the first available
+                if(trackFound === false){
+                    for (var i = 0; i < (tracks.length); i++) {
+                        var trackLang = tracks[i].language;
                         if (trackLang) {
                             tracks[i].mode = "showing";
                             this.ccLang = this.transcriptLang;
@@ -174,6 +201,12 @@ function BrightcovePlayerXblock(runtime, element) {
                     }
                 }
             }
+        },
+        ccAndTranscriptMatch: function(){
+          if(this.ccLang)
+            return this.ccLang.substr(0,2) == this.transcriptLang.substr(0,2);
+
+          return false;
         },
         showTranscript: function() {
             // transcript direction control

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ BLOCKS_CHILDREN = [
 
 setup(
     name='xblock-ooyala-player',
-    version='4.0.2',
+    version='4.0.3',
     description='XBlock - Ooyala Video Player',
     packages=['ooyala_player'],
     install_requires=[


### PR DESCRIPTION
CC and transcripts' language codes are sometimes in 2 and 4 letter codes. Update match logic to try both 4 and 2 letter codes for matching. 