### PR TITLE
MCKIN-25650 Fix print transcript in windows

### DIFF
--- a/ooyala_player/public/js/brightcove_player.js
+++ b/ooyala_player/public/js/brightcove_player.js
@@ -115,7 +115,7 @@ function BrightcovePlayerXblock(runtime, element) {
                 w.document.close();
                 w.focus();
                 w.print();
-                w.close();
+                setTimeout(function(){w.close();}, 100)
             },
             downloadTranscript: function () {
                 var currentSelected = $('.transcript-track.selected', element);

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ BLOCKS_CHILDREN = [
 
 setup(
     name='xblock-ooyala-player',
-    version='4.1.0',
+    version='4.1.1',
     description='XBlock - Ooyala Video Player',
     packages=['ooyala_player'],
     install_requires=[


### PR DESCRIPTION
Jira ticket: https://edx-wiki.atlassian.net/browse/MCKIN-25650

Add 100ms delay for closing command to append in browser event queue after print command as expected.
Without the delay, the close command is ran before print command in windows, since print command takes some time to execute and register in event queue.