### PR TITLE
MCKIN-28307 - Don't display transcript for Lightchild block 

### DIFF
--- a/ooyala_player/ooyala_player.py
+++ b/ooyala_player/ooyala_player.py
@@ -97,7 +97,11 @@ class OoyalaPlayerMixin(I18NService, BrightcovePlayerMixin):
         """
         Player view, displayed to the student
         """
-        transcript = self.transcript.render(i18n_service=self.i18n_service)
+        if hasattr(self, 'lightchild_block_type'):
+            # Don't display transcript in case of OoyalaPlayerLightChildBlock
+            transcript = ''
+        else:
+            transcript = self.transcript.render(i18n_service=self.i18n_service)
 
         context = {
             'dom_id': 'bcove-' + self._get_unique_id(),

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ BLOCKS_CHILDREN = [
 
 setup(
     name='xblock-ooyala-player',
-    version='4.1.1',
+    version='4.1.2',
     description='XBlock - Ooyala Video Player',
     packages=['ooyala_player'],
     install_requires=[


### PR DESCRIPTION
Don't display transcript when `OoyalaPlayerLightChildBlock` is used since in case of brightcove as child xblock we don't display transcripts.