### PR TITLE
MCKIN-29477 - Course and Usage ID string conversion

### DIFF
--- a/ooyala_player/ooyala_player.py
+++ b/ooyala_player/ooyala_player.py
@@ -118,9 +118,9 @@ class OoyalaPlayerMixin(I18NService, BrightcovePlayerMixin):
         """
 
         try:
-            course_id = self.course_id.to_deprecated_string()
+            course_id = str(self.course_id)
             usage_id = self.course_id.make_usage_key(self.scope_ids.block_type, self.location.name)
-            usage_id = usage_id.to_deprecated_string().replace('/', ';_')
+            usage_id = str(usage_id).replace('/', ';_')
         except AttributeError:
             # workaround for workbench
             course_id = None


### PR DESCRIPTION
`xblock_view` is called when this xblock is displayed as a child xblock. Which fails because `to_deprecated_string` has been dropped since `edx-opaque-key` since [version 1](https://github.com/edx/opaque-keys/pull/103)